### PR TITLE
Handle the case where DemoActivity is killed by the system when custom tabs is opened

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivityDestroyedCallback.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivityDestroyedCallback.java
@@ -1,0 +1,75 @@
+package com.braintreepayments.browserswitch;
+
+import android.app.Activity;
+import android.app.Application;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Launches the specified activity when BrowserSwitchActivity is destroyed.
+ */
+public class BrowserSwitchActivityDestroyedCallback implements Application.ActivityLifecycleCallbacks {
+
+    @Nullable
+    private static BrowserSwitchActivityDestroyedCallback sInstance = null;
+
+    @NonNull
+    private final Intent initialActivityIntent;
+
+    private BrowserSwitchActivityDestroyedCallback(@NonNull Intent initialActivityIntent) {
+        this.initialActivityIntent = initialActivityIntent;
+    }
+
+    /**
+     * @param intent the intent of the activity to launch when the BrowserSwitchActivity is destroyed
+     */
+    @MainThread
+    static void register(@NonNull Application application, @NonNull Intent intent) {
+        unregister(application);
+        sInstance = new BrowserSwitchActivityDestroyedCallback(intent);
+        application.registerActivityLifecycleCallbacks(sInstance);
+    }
+
+    @MainThread
+    static void unregister(@NonNull Application application) {
+        if (sInstance != null) {
+            application.unregisterActivityLifecycleCallbacks(sInstance);
+            sInstance = null;
+        }
+    }
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
+
+    @Override
+    public void onActivityStarted(Activity activity) {}
+
+    @Override
+    public void onActivityResumed(Activity activity) {}
+
+    @Override
+    public void onActivityPaused(Activity activity) {}
+
+    @Override
+    public void onActivityStopped(Activity activity) {}
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+        // https://stackoverflow.com/questions/39726547/i-want-to-close-chrome-custom-tab-when-action-button-is-clicked
+        // Relaunch ourselves, bringing ourselves to the front, when the BrowserSwitchActivity
+        // self-finishes.
+        if (activity instanceof BrowserSwitchActivity) {
+            Intent relaunchActivityIntent = new Intent(initialActivityIntent)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            activity.startActivity(relaunchActivityIntent);
+        }
+    }
+}
+

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -1,7 +1,5 @@
 package com.braintreepayments.browserswitch;
 
-import android.app.Activity;
-import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
@@ -58,51 +56,7 @@ public abstract class BrowserSwitchFragment extends Fragment {
         } else {
             mRequestCode = Integer.MIN_VALUE;
         }
-        requireActivity().getApplication().registerActivityLifecycleCallbacks(lifecycleCallbacks);
-
     }
-
-    @Override
-    public void onDestroy() {
-        requireActivity().getApplication().unregisterActivityLifecycleCallbacks(lifecycleCallbacks);
-        super.onDestroy();
-    }
-
-    private Application.ActivityLifecycleCallbacks lifecycleCallbacks = new Application.ActivityLifecycleCallbacks() {
-        @Override
-        public void onActivityCreated(Activity activity, Bundle savedInstanceState) { }
-
-        @Override
-        public void onActivityStarted(Activity activity) { }
-
-        @Override
-        public void onActivityResumed(Activity activity) { }
-
-        @Override
-        public void onActivityPaused(Activity activity) { }
-
-        @Override
-        public void onActivityStopped(Activity activity) { }
-
-        @Override
-        public void onActivitySaveInstanceState(Activity activity, Bundle outState) { }
-
-        @Override
-        public void onActivityDestroyed(Activity activity) {
-            // https://stackoverflow.com/questions/39726547/i-want-to-close-chrome-custom-tab-when-action-button-is-clicked
-            // Relaunch ourselves, bringing ourselves to the front, when the BrowserSwitchActivity
-            // self-finishes.
-            if (activity instanceof BrowserSwitchActivity) {
-                Activity myActivity = getActivity();
-                if (myActivity != null) {
-                    Intent initialIntent = myActivity.getIntent();
-                    Intent relaunchIntent = new Intent(initialIntent)
-                            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    myActivity.startActivity(relaunchIntent);
-                }
-            }
-        }
-    };
 
     @Override
     public void onResume() {
@@ -120,6 +74,9 @@ public abstract class BrowserSwitchFragment extends Fragment {
             } else {
                 onBrowserSwitchResult(requestCode, BrowserSwitchResult.CANCELED, null);
             }
+            BrowserSwitchActivityDestroyedCallback.unregister(requireActivity().getApplication());
+        } else {
+            BrowserSwitchActivityDestroyedCallback.register(requireActivity().getApplication(), requireActivity().getIntent());
         }
     }
 


### PR DESCRIPTION
Handle the case where DemoActivity is killed by the system when custom tabs is opened

Correctly manage the flow if you enable the "don't keep activities" toggle in the system developer options:

Without this option enabled, and before this fix: the flow was:
* `DemoActivity` (with `DemoFragment` extends `BrowserSwitchFragment`) registers an `ActivityLifecycleCallbacks`.
* `DemoActivity` launches chrome custom tabs
* Chrome custom tabs launches `BrowserSwitchActivity` via the deep link
* `BrowserSwitchActivity` `finish()`es itself
* The `ActivityLifecycleCallbacks` is notified of `onActivityDestroyed()` for `BrowserSwitchActivity`,  and brings `DemoActivity` back to the front of the task stack, killing chrome custom tabs, by relaunching `DemoActivity`'s intent with the `CLEAR_TOP` flag.

Before this fix, with "don't keep activities" toggle on, we had a problem:
* `DemoActivity` (with `DemoFragment` extends `BrowserSwitchFragment`) registers an `ActivityLifecycleCallbacks`.
* `DemoActivity` launches chrome custom tabs
* `DemoActivity` is destroyed, and the `ActivityLifecycleCallbacks` is unregistered.
* Chrome custom tabs launches `BrowserSwitchActivity` via the deep link
* `BrowserSwitchActivity` `finish()`es itself
* The `ActivityLifecycleCallbacks` is unregistered, so it's not notified. It can't bring `DemoActivity` back to the front, so chrome custom tabs stays on top.

The fix:
* `DemoActivity` (with `DemoFragment` extends `BrowserSwitchFragment`) registers an `ActivityLifecycleCallbacks`, but which isn't a member of `DemoFragment`. It's outside, in a separate class, held in static field `BrowserSwitchActivityDestroyedCallback.instance`.
* `DemoActivity` launches chrome custom tabs
* `DemoActivity` is destroyed, but the `ActivityLifecycleCallbacks` is still registered. But `DemoActivity` isn't leaked, as this callbacks instance isn't held by `DemoActivity`.
* Chrome custom tabs launches `BrowserSwitchActivity` via the deep link
* `BrowserSwitchActivity` `finish()`es itself
* The `ActivityLifecycleCallbacks` is notified of `onActivityDestroyed()` for `BrowserSwitchActivity` and brings `DemoActivity` (along with `DemoFragment` extends `BrowserSwitchFragment`)  back to the front of the task stack, killing chrome custom tabs, by relaunching `DemoActivity`'s intent with the `CLEAR_TOP` flag.
* `BrowserSwitchFragment.onResume()` unregisters the `ActivityLifecycleCallbacks` instance which resets its static `instance` field to `null`